### PR TITLE
fix(forge): use float total cmp instead partial (#10005)

### DIFF
--- a/crates/cli/src/utils/suggestions.rs
+++ b/crates/cli/src/utils/suggestions.rs
@@ -1,5 +1,4 @@
 //! Helper functions for suggesting alternative values for a possibly erroneous user input.
-use std::cmp::Ordering;
 
 /// Filters multiple strings from a given list of possible values which are similar
 /// to the passed in value `v` within a certain confidence by least confidence.
@@ -17,7 +16,7 @@ where
         .map(|pv| (strsim::jaro_winkler(v, pv.as_ref()), pv.as_ref().to_owned()))
         .filter(|(similarity, _)| *similarity > 0.8)
         .collect();
-    candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
+    candidates.sort_by(|a, b| a.0.total_cmp(&b.0));
     candidates.into_iter().map(|(_, pv)| pv).collect()
 }
 

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -147,7 +147,7 @@ impl ContractsByArtifact {
                     None
                 }
             })
-            .min_by(|(score1, _), (score2, _)| score1.partial_cmp(score2).unwrap())
+            .min_by(|(score1, _), (score2, _)| score1.total_cmp(score2))
             .map(|(_, data)| data)
     }
 

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -373,9 +373,7 @@ fn diff(tests: Vec<SuiteTestResult>, snaps: Vec<GasSnapshotEntry>) -> Result<()>
     let mut overall_gas_change = 0i128;
     let mut overall_gas_used = 0i128;
 
-    diffs.sort_by(|a, b| {
-        a.gas_diff().abs().partial_cmp(&b.gas_diff().abs()).unwrap_or(Ordering::Equal)
-    });
+    diffs.sort_by(|a, b| a.gas_diff().abs().total_cmp(&b.gas_diff().abs()));
 
     for diff in diffs {
         let gas_change = diff.gas_change();
@@ -401,7 +399,7 @@ fn diff(tests: Vec<SuiteTestResult>, snaps: Vec<GasSnapshotEntry>) -> Result<()>
 
 fn fmt_pct_change(change: f64) -> String {
     let change_pct = change * 100.0;
-    match change.partial_cmp(&0.0).unwrap_or(Ordering::Equal) {
+    match change.total_cmp(&0.0) {
         Ordering::Less => format!("{change_pct:.3}%").green().to_string(),
         Ordering::Equal => {
             format!("{change_pct:.3}%")


### PR DESCRIPTION
fix(forge): use total cmp instead partial

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

Bug Fixes:
- Fixes a potential panic when comparing floating point numbers that are NaN.