### PR TITLE
Revert "fix(forge): use float total cmp instead partial (#10005)"

### DIFF
--- a/crates/cli/src/utils/suggestions.rs
+++ b/crates/cli/src/utils/suggestions.rs
@@ -1,4 +1,5 @@
 //! Helper functions for suggesting alternative values for a possibly erroneous user input.
+use std::cmp::Ordering;
 
 /// Filters multiple strings from a given list of possible values which are similar
 /// to the passed in value `v` within a certain confidence by least confidence.
@@ -16,7 +17,7 @@ where
         .map(|pv| (strsim::jaro_winkler(v, pv.as_ref()), pv.as_ref().to_owned()))
         .filter(|(similarity, _)| *similarity > 0.8)
         .collect();
-    candidates.sort_by(|a, b| a.0.total_cmp(&b.0));
+    candidates.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(Ordering::Equal));
     candidates.into_iter().map(|(_, pv)| pv).collect()
 }
 

--- a/crates/common/src/contracts.rs
+++ b/crates/common/src/contracts.rs
@@ -147,7 +147,7 @@ impl ContractsByArtifact {
                     None
                 }
             })
-            .min_by(|(score1, _), (score2, _)| score1.total_cmp(score2))
+            .min_by(|(score1, _), (score2, _)| score1.partial_cmp(score2).unwrap())
             .map(|(_, data)| data)
     }
 

--- a/crates/forge/bin/cmd/snapshot.rs
+++ b/crates/forge/bin/cmd/snapshot.rs
@@ -373,7 +373,9 @@ fn diff(tests: Vec<SuiteTestResult>, snaps: Vec<GasSnapshotEntry>) -> Result<()>
     let mut overall_gas_change = 0i128;
     let mut overall_gas_used = 0i128;
 
-    diffs.sort_by(|a, b| a.gas_diff().abs().total_cmp(&b.gas_diff().abs()));
+    diffs.sort_by(|a, b| {
+        a.gas_diff().abs().partial_cmp(&b.gas_diff().abs()).unwrap_or(Ordering::Equal)
+    });
 
     for diff in diffs {
         let gas_change = diff.gas_change();
@@ -399,7 +401,7 @@ fn diff(tests: Vec<SuiteTestResult>, snaps: Vec<GasSnapshotEntry>) -> Result<()>
 
 fn fmt_pct_change(change: f64) -> String {
     let change_pct = change * 100.0;
-    match change.total_cmp(&0.0) {
+    match change.partial_cmp(&0.0).unwrap_or(Ordering::Equal) {
         Ordering::Less => format!("{change_pct:.3}%").green().to_string(),
         Ordering::Equal => {
             format!("{change_pct:.3}%")


### PR DESCRIPTION
Reverts Dargon789/foundry#17

## Summary by Sourcery

Reverts the change to use total_cmp for comparing floating point numbers, and uses partial_cmp instead.