### PR TITLE
bug(forge)!: strip "revert: " from  vm.expectRevert reason (#10144)

### DIFF
--- a/crates/cheatcodes/src/test/revert_handlers.rs
+++ b/crates/cheatcodes/src/test/revert_handlers.rs
@@ -108,7 +108,12 @@ fn handle_revert(
         } else {
             (&stringify(&actual_revert), &stringify(expected_reason))
         };
-        Err(fmt_err!("Error != expected error: {} != {}", actual, expected,))
+
+        if expected == actual {
+            return Ok(());
+        }
+
+        Err(fmt_err!("Error != expected error: {} != {}", actual, expected))
     }
 }
 

--- a/crates/forge/tests/cli/failure_assertions.rs
+++ b/crates/forge/tests/cli/failure_assertions.rs
@@ -50,8 +50,8 @@ forgetest!(expect_revert_tests_should_fail, |prj, cmd| {
 [FAIL: next call did not revert as expected] testShouldFailExpectRevertDidNotRevert() ([GAS])
 [FAIL: Error != expected error: but reverts with this message != should revert with this message] testShouldFailExpectRevertErrorDoesNotMatch() ([GAS])
 [FAIL: next call did not revert as expected] testShouldFailRevertNotOnImmediateNextCall() ([GAS])
-[FAIL: revert: some message] testShouldFailexpectCheatcodeRevertForCreate() ([GAS])
-[FAIL: revert: revert] testShouldFailexpectCheatcodeRevertForExtCall() ([GAS])
+[FAIL: some message] testShouldFailexpectCheatcodeRevertForCreate() ([GAS])
+[FAIL: revert] testShouldFailexpectCheatcodeRevertForExtCall() ([GAS])
 Suite result: FAILED. 0 passed; 7 failed; 0 skipped; [ELAPSED]
 ...
 "#,
@@ -238,7 +238,7 @@ forgetest!(mem_safety_test_should_fail, |prj, cmd| {
         r#"[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 ...
-[FAIL: revert: Expected call to fail] testShouldFailExpectSafeMemoryCall() ([GAS])
+[FAIL: Expected call to fail] testShouldFailExpectSafeMemoryCall() ([GAS])
 [FAIL: memory write at offset 0x100 of size 0x60 not allowed; safe range: (0x00, 0x60] U (0x80, 0x100]] testShouldFailExpectSafeMemory_CALL() ([GAS])
 [FAIL: memory write at offset 0x100 of size 0x60 not allowed; safe range: (0x00, 0x60] U (0x80, 0x100]] testShouldFailExpectSafeMemory_CALLCODE() ([GAS])
 [FAIL: memory write at offset 0xA0 of size 0x20 not allowed; safe range: (0x00, 0x60] U (0x80, 0xA0]; counterexample: calldata=[..] args=[..]] testShouldFailExpectSafeMemory_CALLDATACOPY(uint256) (runs: 0, [AVG_GAS])
@@ -336,7 +336,7 @@ contract FailingSetupTest is DSTest {
         r#"[COMPILING_FILES] with [SOLC_VERSION]
 [SOLC_VERSION] [ELAPSED]
 ...
-[FAIL: revert: setup failed predictably] setUp() ([GAS])
+[FAIL: setup failed predictably] setUp() ([GAS])
 Suite result: FAILED. 0 passed; 1 failed; 0 skipped; [ELAPSED]
 ...
 "#

--- a/crates/forge/tests/cli/script.rs
+++ b/crates/forge/tests/cli/script.rs
@@ -152,7 +152,7 @@ forgetest_async!(assert_exit_code_error_on_failure_script, |prj, cmd| {
 
     // run command and assert error exit code
     cmd.assert_failure().stderr_eq(str![[r#"
-Error: script failed: revert: failed
+Error: script failed: failed
 
 "#]]);
 });
@@ -168,7 +168,7 @@ forgetest_async!(assert_exit_code_error_on_failure_script_with_json, |prj, cmd| 
 
     // run command and assert error exit code
     cmd.assert_failure().stderr_eq(str![[r#"
-Error: script failed: revert: failed
+Error: script failed: failed
 
 "#]]);
 });

--- a/crates/forge/tests/cli/test_cmd.rs
+++ b/crates/forge/tests/cli/test_cmd.rs
@@ -893,17 +893,17 @@ Compiler run successful!
 
 Ran 4 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
 [PASS] testA() ([GAS])
-[FAIL: revert: testB failed] testB() ([GAS])
+[FAIL: testB failed] testB() ([GAS])
 [PASS] testC() ([GAS])
-[FAIL: revert: testD failed] testD() ([GAS])
+[FAIL: testD failed] testD() ([GAS])
 Suite result: FAILED. 2 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 2 tests passed, 2 failed, 0 skipped (4 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL: revert: testB failed] testB() ([GAS])
-[FAIL: revert: testD failed] testD() ([GAS])
+[FAIL: testB failed] testB() ([GAS])
+[FAIL: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 2 tests succeeded
 
@@ -917,16 +917,16 @@ Encountered a total of 2 failing tests, 2 tests succeeded
 No files changed, compilation skipped
 
 Ran 2 tests for test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL: revert: testB failed] testB() ([GAS])
-[FAIL: revert: testD failed] testD() ([GAS])
+[FAIL: testB failed] testB() ([GAS])
+[FAIL: testD failed] testD() ([GAS])
 Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]
 
 Ran 1 test suite [ELAPSED]: 0 tests passed, 2 failed, 0 skipped (2 total tests)
 
 Failing tests:
 Encountered 2 failing tests in test/ReplayFailures.t.sol:ReplayFailuresTest
-[FAIL: revert: testB failed] testB() ([GAS])
-[FAIL: revert: testD failed] testD() ([GAS])
+[FAIL: testB failed] testB() ([GAS])
+[FAIL: testD failed] testD() ([GAS])
 
 Encountered a total of 2 failing tests, 0 tests succeeded
 
@@ -2123,8 +2123,8 @@ forgetest_init!(should_generate_junit_xml_report, |prj, cmd| {
             <system-out>[FAIL: panic: assertion failed (0x01)] test_junit_assert_fail() ([GAS])</system-out>
         </testcase>
         <testcase name="test_junit_revert_fail()" time="[..]">
-            <failure message="revert: Revert"/>
-            <system-out>[FAIL: revert: Revert] test_junit_revert_fail() ([GAS])</system-out>
+            <failure message="Revert"/>
+            <system-out>[FAIL: Revert] test_junit_revert_fail() ([GAS])</system-out>
         </testcase>
         <system-out>Suite result: FAILED. 0 passed; 2 failed; 0 skipped; [ELAPSED]</system-out>
     </testsuite>

--- a/crates/forge/tests/it/invariant.rs
+++ b/crates/forge/tests/it/invariant.rs
@@ -32,11 +32,11 @@ async fn test_invariant_with_alias() {
         BTreeMap::from([(
             "default/fuzz/invariant/common/InvariantTest1.t.sol:InvariantTest",
             vec![
-                ("invariant_neverFalse()", false, Some("revert: false".into()), None, None),
+                ("invariant_neverFalse()", false, Some("false".into()), None, None),
                 (
                     "statefulFuzz_neverFalseWithInvariantAlias()",
                     false,
-                    Some("revert: false".into()),
+                    Some("false".into()),
                     None,
                     None,
                 ),
@@ -84,13 +84,7 @@ async fn test_invariant_filters() {
             ),
             (
                 "default/fuzz/invariant/target/TargetSenders.t.sol:TargetSenders",
-                vec![(
-                    "invariantTrueWorld()",
-                    false,
-                    Some("revert: false world".into()),
-                    None,
-                    None,
-                )],
+                vec![("invariantTrueWorld()", false, Some("false world".into()), None, None)],
             ),
         ]),
     );
@@ -104,7 +98,7 @@ async fn test_invariant_filters() {
         )),
         BTreeMap::from([(
             "default/fuzz/invariant/target/TargetInterfaces.t.sol:TargetWorldInterfaces",
-            vec![("invariantTrueWorld()", false, Some("revert: false world".into()), None, None)],
+            vec![("invariantTrueWorld()", false, Some("false world".into()), None, None)],
         )]),
     );
 
@@ -146,7 +140,7 @@ async fn test_invariant_filters() {
                     (
                         "invariantShouldFail()",
                         false,
-                        Some("revert: false world".into()),
+                        Some("false world".into()),
                         None,
                         None,
                     ),
@@ -161,7 +155,7 @@ async fn test_invariant_filters() {
                 vec![(
                     "invariantShouldFail()",
                     false,
-                    Some("revert: it's false".into()),
+                    Some("it's false".into()),
                     None,
                     None,
                 )],
@@ -182,7 +176,7 @@ async fn test_invariant_override() {
         &results,
         BTreeMap::from([(
             "default/fuzz/invariant/common/InvariantReentrancy.t.sol:InvariantReentrancy",
-            vec![("invariantNotStolen()", false, Some("revert: stolen".into()), None, None)],
+            vec![("invariantNotStolen()", false, Some("stolen".into()), None, None)],
         )]),
     );
 }
@@ -203,7 +197,7 @@ async fn test_invariant_fail_on_revert() {
             vec![(
                 "statefulFuzz_BrokenInvariant()",
                 false,
-                Some("revert: failed on revert".into()),
+                Some("failed on revert".into()),
                 None,
                 None,
             )],
@@ -245,13 +239,7 @@ async fn test_invariant_inner_contract() {
         &results,
         BTreeMap::from([(
             "default/fuzz/invariant/common/InvariantInnerContract.t.sol:InvariantInnerContract",
-            vec![(
-                "invariantHideJesus()",
-                false,
-                Some("revert: jesus betrayed".into()),
-                None,
-                None,
-            )],
+            vec![("invariantHideJesus()", false, Some("jesus betrayed".into()), None, None)],
         )]),
     );
 }
@@ -541,7 +529,7 @@ async fn test_invariant_fuzzed_selected_targets() {
                 vec![(
                     "invariant_dynamic_targets()",
                     false,
-                    Some("revert: wrong target selector called".into()),
+                    Some("wrong target selector called".into()),
                     None,
                     None,
                 )],
@@ -585,7 +573,7 @@ async fn test_invariant_scrape_values() {
                 vec![(
                     "invariant_value_not_found()",
                     false,
-                    Some("revert: value from return found".into()),
+                    Some("value from return found".into()),
                     None,
                     None,
                 )],
@@ -595,7 +583,7 @@ async fn test_invariant_scrape_values() {
                 vec![(
                     "invariant_value_not_found()",
                     false,
-                    Some("revert: value from logs found".into()),
+                    Some("value from logs found".into()),
                     None,
                     None,
                 )],
@@ -619,7 +607,7 @@ async fn test_invariant_roll_fork_handler() {
                 vec![(
                     "invariant_fork_handler_block()",
                     false,
-                    Some("revert: too many blocks mined".into()),
+                    Some("too many blocks mined".into()),
                     None,
                     None,
                 )],
@@ -629,7 +617,7 @@ async fn test_invariant_roll_fork_handler() {
                 vec![(
                     "invariant_fork_handler_state()",
                     false,
-                    Some("revert: wrong supply".into()),
+                    Some("wrong supply".into()),
                     None,
                     None,
                 )],
@@ -667,14 +655,14 @@ async fn test_invariant_after_invariant() {
                 (
                     "invariant_after_invariant_failure()",
                     false,
-                    Some("revert: afterInvariant failure".into()),
+                    Some("afterInvariant failure".into()),
                     None,
                     None,
                 ),
                 (
                     "invariant_failure()",
                     false,
-                    Some("revert: invariant failure".into()),
+                    Some("invariant failure".into()),
                     None,
                     None,
                 ),
@@ -734,7 +722,7 @@ contract AssumeTest is Test {
 
     cmd.args(["test", "--mt", "invariant_assume"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: revert: Invariant failure]
+[FAIL: Invariant failure]
 ...
 "#]]);
 
@@ -1096,7 +1084,7 @@ contract InvariantSequenceLenTest is Test {
 
     cmd.args(["test", "--mt", "invariant_increment"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: revert: invariant increment failure]
+[FAIL: invariant increment failure]
 	[Sequence] (original: 4, shrunk: 1)
 ...
 "#]]);
@@ -1111,7 +1099,7 @@ contract InvariantSequenceLenTest is Test {
 ...
 Failing tests:
 Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSequenceLenTest
-[FAIL: revert: invariant increment failure]
+[FAIL: invariant increment failure]
 	[Sequence] (original: 4, shrunk: 4)
 		sender=0x00000000000000000000000000000000000018dE addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=setNumber(uint256) args=[1931387396117645594923 [1.931e21]]
 		sender=0x00000000000000000000000000000000000009d5 addr=[src/Counter.sol:Counter]0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f calldata=increment() args=[]
@@ -1134,7 +1122,7 @@ Encountered a total of 1 failing tests, 0 tests succeeded
 ...
 Failing tests:
 Encountered 1 failing test in test/InvariantSequenceLenTest.t.sol:InvariantSequenceLenTest
-[FAIL: revert: invariant increment failure]
+[FAIL: invariant increment failure]
 	[Sequence] (original: 4, shrunk: 4)
 		vm.prank(0x00000000000000000000000000000000000018dE);
 		Counter(0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f).setNumber(1931387396117645594923);
@@ -1220,7 +1208,7 @@ contract OwnableTest is Test {
 
     cmd.args(["test", "--mt", "invariant_never_owner"]).assert_failure().stdout_eq(str![[r#"
 ...
-[FAIL: revert: never owner]
+[FAIL: never owner]
 ...
 "#]]);
 

--- a/testdata/default/cheats/ExpectRevert.t.sol
+++ b/testdata/default/cheats/ExpectRevert.t.sol
@@ -84,6 +84,18 @@ contract ExpectRevertTest is DSTest {
         reverter.revertWithMessage("revert");
     }
 
+    function testExpectRevertWithEncodedErrorPrefix() public {
+        Reverter reverter = new Reverter();
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "my revert reason"));
+        reverter.revertWithMessage("my revert reason");
+
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "A"));
+        reverter.revertWithMessage("A");
+
+        vm.expectRevert(abi.encodeWithSignature("Error(string)", "revert: A"));
+        reverter.revertWithMessage("revert: A");
+    }
+
     function testShouldFailIfExpectRevertWrongString() public {
         Reverter reverter = new Reverter();
         vm.expectRevert("my not so cool error", 0);


### PR DESCRIPTION
* bug(forge)!: strip "revert: " from  vm.expectRevert reason

* Impl update, update decoder:
- match on ContractError:Revert
- move checks before split first chunk / EvmError

---------

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

Strip "revert: " prefix from vm.expectRevert reason in Foundry's error decoding logic

Bug Fixes:
- Modify error decoding to remove the 'revert: ' prefix from error messages, improving consistency in error reporting

Enhancements:
- Refactor error decoding logic to handle different error types more robustly
- Improve string decoding with a new helper function that checks for non-empty strings

Tests:
- Update test cases to remove 'revert: ' prefix from expected error messages
- Add new test cases for error message decoding