### PR TITLE
Potential fix for code scanning alert no. 19: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,6 +295,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [prepare, release-docker, release, cleanup]
     if: failure()
+    permissions:
+      issues: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: JasonEtco/create-an-issue@v2


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/19](https://github.com/Dargon789/foundry/security/code-scanning/19)

To fix the issue, we need to explicitly define the permissions for the `GITHUB_TOKEN` in the `issue` job. Since the job uses the `JasonEtco/create-an-issue@v2` action, it requires `issues: write` permissions. Additionally, we should set other permissions to `read` or remove them entirely if they are not needed. This ensures that the job adheres to the principle of least privilege.

The `permissions` block should be added to the `issue` job, specifying `issues: write` and `contents: read` (the latter is often required for basic repository access).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Specify `issues: write` and `contents: read` permissions for the `issue` job in `.github/workflows/release.yml` to fix the workflow permissions alert.