### PR TITLE
fix(fmt): handle trailing coments between base contracts (#12127)

### DIFF
--- a/crates/fmt/src/state/sol.rs
+++ b/crates/fmt/src/state/sol.rs
@@ -288,6 +288,14 @@ impl<'ast> State<'_, 'ast> {
         self.print_ident(name);
         self.nbsp();
 
+        if let Some(layout) = layout
+            && !self.handle_span(layout.span, false)
+        {
+            self.word("layout at ");
+            self.print_expr(layout.slot);
+            self.print_sep(Separator::Space);
+        }
+
         if let Some(first) = bases.first().map(|base| base.span())
             && let Some(last) = bases.last().map(|base| base.span())
             && self.inline_config.is_disabled(first.to(last))
@@ -296,26 +304,30 @@ impl<'ast> State<'_, 'ast> {
         } else if !bases.is_empty() {
             self.word("is");
             self.space();
-            for (pos, base) in bases.iter().delimited() {
+            let last = bases.len() - 1;
+            for (i, base) in bases.iter().enumerate() {
                 if !self.handle_span(base.span(), false) {
                     self.print_modifier_call(base, false);
-                    if !pos.is_last {
+                    if i != last {
                         self.word(",");
-                        self.space();
+                        if self
+                            .print_comments(
+                                bases[i + 1].span().lo(),
+                                CommentConfig::skip_ws().mixed_prev_space().mixed_post_nbsp(),
+                            )
+                            .is_none()
+                        {
+                            self.space();
+                        }
                     }
                 }
             }
-            self.space();
+            if !self.print_trailing_comment(bases.last().unwrap().span().hi(), None) {
+                self.space();
+            }
             self.s.offset(-self.ind);
         }
         self.end();
-        if let Some(layout) = layout
-            && !self.handle_span(layout.span, false)
-        {
-            self.word("layout at ");
-            self.print_expr(layout.slot);
-            self.print_sep(Separator::Space);
-        }
 
         self.print_word("{");
         self.end();

--- a/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/bracket-spacing.fmt.sol
@@ -39,3 +39,15 @@ contract ERC20DecimalsMock is ERC20 {
         _decimals = decimals_;
     }
 }
+
+contract SomeContract is
+    ERC165Upgradeable, // 1 inherited component
+    ISomeContract // 4 inherited components
+{ }
+
+contract AnotherContract is
+    Adminable, /* 1 inherited components */
+    UUPSUpgradeable /* 1 inherited component */
+{ }
+
+contract WithLayoutAndBase layout at 69 is Base { }

--- a/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/contract-new-lines.fmt.sol
@@ -50,3 +50,15 @@ contract ERC20DecimalsMock is ERC20 {
     }
 
 }
+
+contract SomeContract is
+    ERC165Upgradeable, // 1 inherited component
+    ISomeContract // 4 inherited components
+{}
+
+contract AnotherContract is
+    Adminable, /* 1 inherited components */
+    UUPSUpgradeable /* 1 inherited component */
+{}
+
+contract WithLayoutAndBase layout at 69 is Base {}

--- a/crates/fmt/testdata/ContractDefinition/fmt.sol
+++ b/crates/fmt/testdata/ContractDefinition/fmt.sol
@@ -45,3 +45,15 @@ contract ERC20DecimalsMock is ERC20 {
         _decimals = decimals_;
     }
 }
+
+contract SomeContract is
+    ERC165Upgradeable, // 1 inherited component
+    ISomeContract // 4 inherited components
+{}
+
+contract AnotherContract is
+    Adminable, /* 1 inherited components */
+    UUPSUpgradeable /* 1 inherited component */
+{}
+
+contract WithLayoutAndBase layout at 69 is Base {}

--- a/crates/fmt/testdata/ContractDefinition/original.sol
+++ b/crates/fmt/testdata/ContractDefinition/original.sol
@@ -17,7 +17,7 @@ contract SampleContract {
     // comment 16
     external /* comment 17 */
     pure
-    returns(uint256) 
+    returns(uint256)
     // comment 18
     { // comment 19
         return arg1 > arg2 ? arg1 : arg2;
@@ -38,3 +38,15 @@ contract ERC20DecimalsMock is ERC20 {
         _decimals = decimals_;
     }
 }
+
+contract SomeContract is
+    ERC165Upgradeable, // 1 inherited component
+    ISomeContract // 4 inherited components
+{ }
+
+contract AnotherContract is
+    Adminable, /* 1 inherited components */
+    UUPSUpgradeable /* 1 inherited component */
+{ }
+
+contract WithLayoutAndBase layout at 69 is Base {}


### PR DESCRIPTION
* fix(fmt): account for ternary operators when estimating size

* fix(fmt): handle comments between inherited base contracts

* test: layout + base inheritance

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [x] Added Documentation
- [x] Breaking changes

## Summary by Sourcery

Fix contract definition formatting to correctly handle ternary operators, comments between and after inherited base contracts, and layout specifiers, and add tests for these scenarios.

Bug Fixes:
- Account for ternary operators when estimating node sizes.
- Handle comments between inherited base contracts and trailing comments after the last base component.

Enhancements:
- Reorder printing of the layout specifier before the base contracts list.

Tests:
- Add formatting tests for base inheritance with inline and block comments and for contracts with a layout specifier.