### PR TITLE
Potential fix for code scanning alert no. 76: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -162,10 +162,11 @@ jobs:
           PLATFORM_NAME=${{ matrix.os }} ARCH=${{ matrix.arch }} FORGE_BIN_PATH="$BIN" bun ./scripts/prepublish.ts
 
       - name: Sanity Check Binary
-        working-directory: ./npm
+        env:
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
           set -euo pipefail
-          PKG_DIR="./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
+          PKG_DIR="$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
           BIN="$PKG_DIR/bin/forge"
           if [[ "${{ matrix.os }}" == "win32" ]]; then
             BIN="$PKG_DIR/bin/forge.exe"
@@ -185,7 +186,7 @@ jobs:
           fi
 
       - name: Publish ${{ matrix.os }}-${{ matrix.arch }} Binary
-        working-directory: ./npm
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         env:
           PROVENANCE: true
           VERSION_NAME: ${{ steps.release-version.outputs.RELEASE_VERSION }}
@@ -195,9 +196,9 @@ jobs:
         run: |
           set -euo pipefail
 
-          ls -la ./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}
+          ls -la "$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
 
-          bun ./scripts/publish.ts ./@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}
+          bun ./scripts/publish.ts "$ARTIFACT_DIR/@foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
 
           echo "Published @foundry-rs/forge-${{ matrix.os }}-${{ matrix.arch }}"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/76](https://github.com/Dargon789/foundry/security/code-scanning/76)

To mitigate artifact poisoning, we must ensure that downloaded artifacts are extracted only to an isolated directory (not the workspace), and that untrusted data is never used directly without validation. In this workflow, artifacts should only be used from `${{ steps.paths.outputs.artifact_dir }}` (`ARTIFACT_DIR`) and never copied or moved into the workspace unless their contents are strictly validated before use.

Specifically:
- Adjust any steps referencing binaries or package directories to explicitly use the isolated artifact directory location (e.g., `$ARTIFACT_DIR`) rather than the workspace or ambiguous relative paths.
- Ensure that any file you execute, publish, or package is verified (sanity checked) before use.
- In the "Sanity Check Binary" and "Publish" steps, refer to binaries inside the isolated artifact directory, not `./npm/@foundry-rs/forge-...`.
- If necessary, securely copy or move verified artifacts from the isolated directory to the workspace after passing validation, and do not overwrite existing files.
- All references to binaries, especially those used for execution or publishing, should be confined to $ARTIFACT_DIR.
- No step should run code from potentially overwritten workspace files.

The required changes are:
- Edit steps under "Sanity Check Binary" and "Publish ..." to use binaries/packages strictly from the isolated artifact directory (from the environment variable, e.g. `$ARTIFACT_DIR`) rather than the workspace/probably ambiguous paths.
- Update the `working-directory` values or inline the artifact directory as needed.
- If files must be used in the workspace, add a step to securely copy them in after verification.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Mitigate artifact poisoning by isolating and validating downloaded artifacts in the npm workflow

Bug Fixes:
- Ensure downloaded binaries are never extracted or executed from the workspace to prevent artifact poisoning

CI:
- Set ARTIFACT_DIR environment variable and update Sanity Check Binary and Publish steps to reference artifacts from the isolated directory instead of workspace-relative paths