### PR TITLE
fix: node_info label for erigon_get_header_by_number (#12346)

### DIFF
--- a/crates/anvil/src/eth/otterscan/api.rs
+++ b/crates/anvil/src/eth/otterscan/api.rs
@@ -32,7 +32,7 @@ impl EthApi {
         &self,
         number: BlockNumber,
     ) -> Result<Option<AnyRpcBlock>> {
-        node_info!("ots_getApiLevel");
+        node_info!("erigon_getHeaderByNumber");
 
         self.backend.block_by_number(number).await
     }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

Bug Fixes:
- Update the node_info macro argument from "ots_getApiLevel" to "erigon_getHeaderByNumber"