### PR TITLE
Potential fix for code scanning alert no. 103: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -233,8 +233,45 @@ jobs:
           PLATFORM='${{ matrix.os }}'
           ARCH='${{ matrix.arch }}'
 
+          # Basic validation of matrix-derived values to avoid path manipulation
+          case "$TOOL" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid TOOL value: $TOOL" >&2; exit 1 ;;
+          esac
+          case "$PLATFORM" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid PLATFORM value: $PLATFORM" >&2; exit 1 ;;
+          esac
+          case "$ARCH" in
+            (*[!a-zA-Z0-9_-]*|'') echo "ERROR: Invalid ARCH value: $ARCH" >&2; exit 1 ;;
+          esac
+
           PACKAGE_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
+          echo "Preparing to publish package from: $PACKAGE_DIR"
+
+          if [[ ! -d "$PACKAGE_DIR" ]]; then
+            echo "ERROR: Package directory does not exist: $PACKAGE_DIR" >&2
+            exit 1
+          fi
+
+          # Resolve to an absolute path and ensure it stays within ./@foundry-rs
+          ABS_PACKAGE_DIR="$(realpath "$PACKAGE_DIR")"
+          ABS_EXPECTED_ROOT="$(realpath "./@foundry-rs")"
+          case "$ABS_PACKAGE_DIR" in
+            "$ABS_EXPECTED_ROOT"/*) ;;
+            *)
+              echo "ERROR: Resolved package directory is outside expected root:" >&2
+              echo "  ABS_PACKAGE_DIR=$ABS_PACKAGE_DIR" >&2
+              echo "  ABS_EXPECTED_ROOT=$ABS_EXPECTED_ROOT" >&2
+              exit 1
+              ;;
+          esac
+
           ls -la "$PACKAGE_DIR"
+
+          # Minimal sanity check: require a package.json before publishing
+          if [[ ! -f "$PACKAGE_DIR/package.json" ]]; then
+            echo "ERROR: package.json not found in $PACKAGE_DIR; refusing to publish." >&2
+            exit 1
+          fi
 
           bun ./scripts/publish.mjs "$PACKAGE_DIR"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/103](https://github.com/Dargon789/foundry/security/code-scanning/103)

General fix approach: Ensure artifacts are treated as untrusted by (1) keeping them in an isolated directory (already done), and (2) validating any derived paths or contents before they are passed into scripts that may perform privileged actions (like publishing to npm). We should add explicit checks in the `Publish ... Binary` step to ensure that the computed `PACKAGE_DIR` is sane (no path traversal, exists, contains expected files) before invoking `publish.mjs`. This keeps existing functionality while giving CodeQL a clear validation barrier.

Concrete best fix for this snippet: In the `Publish ${{ matrix.os }}-${{ matrix.arch }} Binary` step (lines 221–241), enhance the shell script to:

- Derive `TOOL`, `PLATFORM`, `ARCH`, and `PACKAGE_DIR` as before.
- Reject unexpected values defensively (e.g., only allow a small, known set of characters in each, to prevent path manipulation).
- Confirm that `PACKAGE_DIR` exists, is a directory, and resides strictly under `./@foundry-rs` by resolving it to an absolute real path and checking it has the expected prefix.
- Optionally, confirm that at least a minimal expected structure exists (e.g., that `package.json` and/or `bin/` or a tool binary exists).
- Only after successful validation, run `bun ./scripts/publish.mjs "$PACKAGE_DIR"`.

These edits are localized to the script in the existing `Publish ... Binary` step in `.github/workflows/npm.yml`; no new imports are needed, since we rely on standard POSIX utilities (`realpath`, `case` pattern matches, `test`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden the npm publish workflow against artifact path manipulation by validating matrix-derived parameters and package directories before publishing.

Bug Fixes:
- Add defensive validation for TOOL, PLATFORM, and ARCH values in the npm workflow to prevent malformed or malicious inputs.
- Verify that the computed package directory exists, resides within the expected @foundry-rs root, and contains a package.json before invoking the publish script.