### PR TITLE
Potential fix for code scanning alert no. 108: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -226,6 +226,7 @@ jobs:
           RELEASE_VERSION: ${{ steps.release-version.outputs.RELEASE_VERSION }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          ARTIFACT_DIR: ${{ steps.paths.outputs.artifact_dir }}
         run: |
           set -euo pipefail
 
@@ -245,7 +246,21 @@ jobs:
           esac
 
           PACKAGE_DIR="./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}"
-          echo "Preparing to publish package from: $PACKAGE_DIR"
+          EXPECTED_PKG_NAME="${TOOL}-${PLATFORM}-${ARCH}"
+
+          # Ensure corresponding artifact directory exists in the isolated artifact dir
+          if [[ -z "${ARTIFACT_DIR:-}" ]]; then
+            echo "ERROR: ARTIFACT_DIR is not set; refusing to publish." >&2
+            exit 1
+          fi
+
+          EXPECTED_ARTIFACT_PATH="${ARTIFACT_DIR}/${EXPECTED_PKG_NAME}"
+          if [[ ! -d "$EXPECTED_ARTIFACT_PATH" ]]; then
+            echo "ERROR: Expected artifact directory not found at: $EXPECTED_ARTIFACT_PATH" >&2
+            exit 1
+          fi
+
+          echo "Preparing to publish package from: $PACKAGE_DIR (artifact: $EXPECTED_ARTIFACT_PATH)"
 
           if [[ ! -d "$PACKAGE_DIR" ]]; then
             echo "ERROR: Package directory does not exist: $PACKAGE_DIR" >&2


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/108](https://github.com/Dargon789/foundry/security/code-scanning/108)

In general, to fix artifact poisoning you must: (1) ensure artifacts are downloaded into an isolated temporary directory that cannot overwrite trusted repository files; (2) treat all artifact contents as untrusted and validate any values derived from them before use (especially paths and anything executed or published); and (3) ensure that the workflow only operates on expected directories/files that are clearly linked to the isolated artifact directory.

This workflow already downloads artifacts into `$RUNNER_TEMP/foundry_artifacts`, and the risky part is the publish step that uses `TOOL`, `PLATFORM`, and `ARCH` to build `PACKAGE_DIR` directly under `./@foundry-rs`. To improve the trust boundary without changing existing functional behavior, we can add an explicit check that, for each matrix combination, a corresponding artifact directory exists under the isolated artifact directory and that its name exactly matches the expected package directory name. Then we verify that the workspace `./@foundry-rs/${TOOL}-${PLATFORM}-${ARCH}` directory actually exists and matches this artifact directory name. This asserts that what we are publishing has a one‑to‑one mapping with an expected artifact, and maintains the current behavior of publishing from `./@foundry-rs/...` while adding an extra barrier against artifacts influencing unexpected locations.

Concretely, in the `Publish ... Binary` step (around line 229) we will:
- Export the isolated artifact directory into the step via `env`, reusing `steps.paths.outputs.artifact_dir`.
- Compute `EXPECTED_PKG_NAME="${TOOL}-${PLATFORM}-${ARCH}"`.
- Check that a directory named `"${EXPECTED_PKG_NAME}"` exists directly under `$ARTIFACT_DIR` (e.g. `$ARTIFACT_DIR/${EXPECTED_PKG_NAME}`), failing if it does not.
- Confirm that `$PACKAGE_DIR`’s basename equals `$EXPECTED_PKG_NAME` (it already will) and then proceed with the existing `realpath`‑based confinement and `package.json` checks.
This keeps the functional flow the same while adding a clear dependency on the known isolated artifact directory and tighter validation, addressing the CodeQL variants that stem from untrusted artifact data reaching the publish command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add environment wiring and checks in the npm workflow to verify an expected artifact directory exists for each package before publishing.