### PR TITLE
Potential fix for code scanning alert no. 110: Uncontrolled data used in path expression

### DIFF
--- a/crates/test-utils/src/script.rs
+++ b/crates/test-utils/src/script.rs
@@ -118,6 +118,7 @@ impl ScriptTester {
     fn copy_testdata(root: &Path) -> Result<()> {
         let testdata = Self::testdata_path();
         let from_dir = testdata.join("utils");
+        let canonical_from_dir = from_dir.canonicalize()?;
         let to_dir = root.join("utils");
         fs::create_dir_all(&to_dir)?;
         for entry in fs::read_dir(&from_dir)? {
@@ -138,9 +139,9 @@ impl ScriptTester {
                 // Skip invalid (potentially dangerous) file names
                 continue;
             }
-            // Verify canonicalized file is in from_dir to avoid symlink traversal
+            // Verify canonicalized file is in canonical_from_dir to avoid symlink traversal
             if let Ok(canonical_file) = file.canonicalize() {
-                if !canonical_file.starts_with(&from_dir) {
+                if !canonical_file.starts_with(&canonical_from_dir) {
                     continue;
                 }
             } else {


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/110](https://github.com/Dargon789/foundry/security/code-scanning/110)

In general, to fix uncontrolled path usage you need to ensure that any path derived from potentially untrusted data is (a) structurally safe (no separators, `..`, or absolute paths when only a component is expected) and (b) confined to an expected base directory after resolving symlinks and `..` via canonicalization, before using it in filesystem operations such as `fs::copy`.

In this specific function, `file` comes directly from `fs::read_dir(&from_dir)?`. While `from_dir` is constant in code, the filesystem contents there can still be manipulated. The code already validates `name` to make sure it is a single filename component, and it avoids non‑files using `symlink_metadata`. The main missing piece — which CodeQL is complaining about — is a guarantee that the *resolved* path of `file` is still under `from_dir` (preventing copying from symlink targets outside `from_dir`). The best fix with minimal functional change is to canonicalize both `from_dir` (once) and each `file`, and then ensure that `canonical_file.starts_with(&canonical_from_dir)` before copying. This is similar to the “public folder” example in the background section.

Concretely:
- In `copy_testdata`, compute `let canonical_from_dir = from_dir.canonicalize()?;` before iterating.
- Inside the loop, when canonicalizing each `file`, compare against `canonical_from_dir` rather than `from_dir`. If canonicalization fails for a specific file, skip it (as is already done).
- Keep the existing name validation and file‑type check to avoid regressions.

All edits are within `crates/test-utils/src/script.rs`, limited to the shown `copy_testdata` function. No new imports are needed; `canonicalize` and `starts_with` are already available on `PathBuf`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Harden test data file copying against uncontrolled path usage by validating that canonicalized files remain within the canonical utils source directory.