### PR TITLE
Potential fix for code scanning alert no. 102: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -164,15 +164,29 @@ jobs:
 
           # Derive RELEASE_VERSION from any foundry artifact we downloaded
           # Expected names: foundry_<VERSION>_<platform>_<arch>.{tar.gz,zip}
-          first_file=$(ls "$ARTIFACT_DIR"/foundry_* 2>/dev/null | head -n1 || true)
-          if [[ -z "${first_file}" ]]; then
-            echo "No foundry artifacts found to publish" >&2
+          shopt -s nullglob
+          foundry_files=("$ARTIFACT_DIR"/foundry_*)
+          shopt -u nullglob
+
+          if [[ ${#foundry_files[@]} -eq 0 ]]; then
+            echo "No foundry artifacts found to publish in $ARTIFACT_DIR" >&2
             exit 1
           fi
+
+          first_file="${foundry_files[0]}"
           version_part=$(basename "$first_file")
           version_part=${version_part#foundry_}
-          export RELEASE_VERSION=${version_part%%_*}
-          echo "Detected RELEASE_VERSION=$RELEASE_VERSION"
+          RELEASE_VERSION=${version_part%%_*}
+
+          # Validate derived RELEASE_VERSION to mitigate artifact poisoning
+          # Require a sane version format, e.g. 1.2.3 or 1.2.3-beta.1
+          if [[ ! "$RELEASE_VERSION" =~ ^[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "ERROR: Derived RELEASE_VERSION '$RELEASE_VERSION' from artifact '$first_file' is not a valid version" >&2
+            exit 1
+          fi
+
+          export RELEASE_VERSION
+          echo "Detected RELEASE_VERSION=$RELEASE_VERSION from artifact $first_file"
 
           printf 'RELEASE_VERSION=%s\n' "$RELEASE_VERSION" >>"$GITHUB_OUTPUT"
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/102](https://github.com/Dargon789/foundry/security/code-scanning/102)

To fix this, we should treat the artifact-derived information as untrusted and validate it before use. Specifically, we should (1) strictly validate the `RELEASE_VERSION` extracted from the artifact filename against an expected semantic-version-like pattern, and (2) ensure we only consider artifact filenames that match the expected `foundry_<VERSION>_...` structure. If validation fails, the job should stop rather than proceeding to stage and publish.

Concretely, in `.github/workflows/npm.yml` within the `Derive RELEASE_VERSION` step (lines 150–177), we will:

- Replace the simple `first_file=$(ls "$ARTIFACT_DIR"/foundry_* ...)` logic with:
  - A `shopt -s nullglob` and a glob over `"$ARTIFACT_DIR"/foundry_*` so we avoid parsing `ls` output.
  - A loop to pick the first matching file deterministically.
- After extracting `RELEASE_VERSION`, add a regex check with `[[ "$RELEASE_VERSION" =~ ^[0-9]+(\.[0-9]+)*(-[0-9A-Za-z.-]+)?$ ]]` (or similar) to ensure it looks like a sane version string.
- If no artifacts are found or the version fails validation, print a clear error and exit 1.

This maintains existing behavior (we still choose the first `foundry_*` artifact and derive `RELEASE_VERSION` from its name) while adding verification of the untrusted data, which should satisfy CodeQL and improve security. No new imports or external dependencies are needed; everything is standard bash.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden the npm publish workflow by safely deriving and validating RELEASE_VERSION from downloaded foundry artifacts to mitigate artifact poisoning in CI.

CI:
- Update RELEASE_VERSION derivation in the npm workflow to avoid parsing ls output and instead deterministically select foundry artifacts via shell globbing.
- Validate the version extracted from foundry artifact filenames against a strict semantic-style pattern and fail the job if no valid artifacts or versions are found.