### PR TITLE
Potential fix for code scanning alert no. 102: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -155,13 +155,14 @@ jobs:
           fi
 
           # Reject files with suspicious paths (absolute paths or parent directory traversals)
-          while IFS= read -r path; do
+          # Use null-delimited paths to safely handle filenames with newlines or whitespace
+          while IFS= read -r -d '' path; do
             rel="${path#"$ARTIFACT_DIR"/}"
             if [[ "$rel" == /* ]] || [[ "$rel" == *".."* ]]; then
               echo "ERROR: Suspicious artifact path detected: $rel" >&2
               exit 1
             fi
-          done < <(find "$ARTIFACT_DIR" -type f -print)
+          done < <(find "$ARTIFACT_DIR" -type f -print0)
 
           echo "Artifact validation completed successfully."
 


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/102](https://github.com/Dargon789/foundry/security/code-scanning/102)

To fix the problem, we should (1) continue using an isolated directory for artifacts (already done) and (2) add an explicit validation step that inspects the downloaded artifacts and fails the job if they don’t match expected patterns. This ensures that even if an attacker controls the artifacts, they cannot arbitrarily influence what gets staged and published without passing strict checks; this addresses all variants pointing to the “Stage Binary Into Package” step as a sink.

The best way to fix this without changing core functionality is to insert a new shell step after `Download Release Assets` (and before `Stage Binary Into Package`) that validates `ARTIFACT_DIR`. This step should enforce that:
- The directory exists and is non-empty.
- Only expected file types are present (e.g., `.tar.gz`, `.zip`, `.json`, etc., depending on what is legitimate in your pipeline).
- No suspicious paths (absolute paths, `..`, symlinks) are present that could lead to path traversal or overwriting unintended locations when unpacked by `stage-from-artifact.mjs`.

We will add a step `Validate Downloaded Artifacts` that:
- Uses `find` to list and inspect contents.
- Fails if any file path contains `..` or is absolute.
- Optionally restricts file extensions to a safe set (you can tune this as needed later).
This step will sit between lines 136–137 and 139 in `.github/workflows/npm.yml`, reusing `ARTIFACT_DIR` from `steps.paths.outputs.artifact_dir`. No new external dependencies are required, as we can do this with standard shell utilities.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Validate downloaded artifacts in the npm workflow to mitigate artifact poisoning and path traversal risks.