### PR TITLE
Potential fix for code scanning alert no. 108: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -354,10 +354,10 @@ jobs:
               ART_NAME="$(jq -r '.name // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
               ART_VERSION="$(jq -r '.version // empty' < "$EXPECTED_ARTIFACT_PATH/package.json")"
             else
-              SRC_NAME="$(grep -m1 '"name"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')" || SRC_NAME=""
-              SRC_VERSION="$(grep -m1 '"version"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')" || SRC_VERSION=""
-              ART_NAME="$(grep -m1 '"name"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')" || ART_NAME=""
-              ART_VERSION="$(grep -m1 '"version"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')" || ART_VERSION=""
+              SRC_NAME="$(grep -m1 '"name"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              SRC_VERSION="$(grep -m1 '"version"' "$PACKAGE_DIR/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              ART_NAME="$(grep -m1 '"name"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"name"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
+              ART_VERSION="$(grep -m1 '"version"' "$EXPECTED_ARTIFACT_PATH/package.json" | sed -E 's/.*"version"[[:space:]]*:[[:space:]]*"([^"]*)".*/\1/')"
             fi
 
             if [[ -n "$SRC_NAME" && -n "$ART_NAME" && "$SRC_NAME" != "$ART_NAME" ]]; then


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/108](https://github.com/Dargon789/foundry/security/code-scanning/108)

In general terms, we want to (a) continue extracting artifacts into an isolated temp directory, and (b) add explicit validation that the downloaded artifacts match our expectations before we perform any sensitive actions such as publishing. That means: ensure the expected per‑platform artifact path exists, ensure it does not contain unexpected path components, and, crucially, sanity‑check that what we are about to publish from the repo (`PACKAGE_DIR`) is consistent with the corresponding artifact (`EXPECTED_ARTIFACT_PATH`). By tightening this contract, we make it clear to CodeQL (and to future maintainers) that artifact content is treated as untrusted input and only used after validation.

The best targeted fix here, without changing existing functionality, is to add stronger validation immediately before publishing: (1) ensure that the artifact directory for this TOOL/PLATFORM/ARCH contains at least some expected “marker” (e.g., a `package.json` that matches the one in the repo, or a simple manifest file), and (2) ensure that the artifact path does not escape the isolated artifacts root. We already validate `PACKAGE_DIR` resides under `./@foundry-rs`; we can mirror that for `EXPECTED_ARTIFACT_PATH` relative to `$ARTIFACT_DIR`, and add a minimal cross‑check to ensure the artifact’s `package.json` (if present) agrees with the source one’s name/version. This is a cheap safeguard that uses only shell tools and does not alter the publish semantics when artifacts are honest.

Concretely, in `.github/workflows/npm.yml` within the `Publish ${{ matrix.os }}-${{ matrix.arch }} Binary` step (lines 274–337), we will augment the shell block as follows:

- After computing `EXPECTED_ARTIFACT_PATH` and confirming the directory exists, add:
  - A `realpath` containment check to ensure `EXPECTED_ARTIFACT_PATH` resolves under `$ARTIFACT_DIR`.
  - A small check that if both `$EXPECTED_ARTIFACT_PATH/package.json` and `$PACKAGE_DIR/package.json` exist, their `"name"` and `"version"` fields match (using `jq` if available or a simple `grep/sed` fallback). If they don’t, we abort publishing.
- These checks treat the artifact content as an untrusted proposal that must match the already‑checked‑out source layout before proceeding, thereby addressing the artifact‑poisoning concern while leaving overall behavior unchanged for valid builds.

No additional imports or external actions are required; all logic is bash using standard tools available on `ubuntu-latest`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Harden npm publish workflow artifact handling to mitigate artifact poisoning risks by validating artifact paths and contents before publishing.

CI:
- Add a realpath-based containment check to ensure the resolved artifact directory remains within the isolated artifacts root in the npm publish workflow.
- Validate that the artifact package.json, when present, matches the source package.json name and version before allowing publish in the npm workflow.