### PR TITLE
Potential fix for code scanning alert no. 108: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -113,6 +113,22 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate Trusted Artifact Source
+        run: |
+          set -euo pipefail
+
+          if [[ "${{ github.event_name }}" == "workflow_run" ]]; then
+            [[ "${{ github.event.workflow_run.conclusion }}" == "success" ]] || { echo "ERROR: Upstream workflow_run did not succeed."; exit 1; }
+            [[ "${{ github.event.workflow_run.head_repository.full_name }}" == "${{ github.repository }}" ]] || { echo "ERROR: Upstream run repository mismatch."; exit 1; }
+            [[ "${{ github.event.workflow_run.event }}" != "pull_request" ]] || { echo "ERROR: Refusing artifacts from pull_request-triggered upstream runs."; exit 1; }
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            [[ -n "${{ inputs.run_id }}" ]] || { echo "ERROR: inputs.run_id is required for workflow_dispatch."; exit 1; }
+            [[ "${{ inputs.run_id }}" =~ ^[0-9]+$ ]] || { echo "ERROR: inputs.run_id must be numeric."; exit 1; }
+          else
+            echo "ERROR: Unsupported event: ${{ github.event_name }}"
+            exit 1
+          fi
+
       - name: Set Isolated Artifact Directory
         id: paths
         run: |


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/108](https://github.com/Dargon789/foundry/security/code-scanning/108)

To fix this without changing intended functionality, add a **trust gate** before download/publish that enforces the upstream run context is trusted (same repository, expected workflow, successful conclusion, non-fork PR context) and fail closed otherwise. This addresses all alert variants at once by preventing untrusted artifact sources from reaching the publish sink.

Best concrete fix in `.github/workflows/npm.yml`:
1. In `publish-arch` job, add a new early step (after checkout or before download) to validate trigger context.
2. For `workflow_run` events, verify:
   - `github.event.workflow_run.conclusion == 'success'`
   - `github.event.workflow_run.head_repository.full_name == github.repository`
   - `github.event.workflow_run.event != 'pull_request'`
3. For `workflow_dispatch`, require `inputs.run_id` to be numeric and reject missing/invalid values.
4. Keep existing isolated artifact path and path checks.

No new imports/dependencies are required; this is pure workflow YAML/bash hardening.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Add a validation step in the npm workflow to ensure artifacts originate from successful runs in the same repository and to validate workflow_dispatch inputs before proceeding.