### PR TITLE
fix(forge): adjust gas assertion CounterWithFallback (foundry-rs#14465 )

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -15,15 +15,44 @@ on:
         type: string
         default: "stable,nightly"
       repos:
-        description: "Comma-separated list of repos to benchmark (e.g., ithacaxyz/account:main,Vectorized/solady)"
+        description: "Comma-separated repos to benchmark. Each entry: org/repo[:rev][ <extra args>] (e.g. vectorized/solady:v0.1.26 --nmc BrokenTest). Leave empty to use the per-benchmark default repo lists."
         required: false
         type: string
-        default: "ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22"
+        default: ""
 
 env:
-  ITHACAXYZ_ACCOUNT: "ithacaxyz/account:v0.3.2"
-  VECTORIZED_SOLADY: "Vectorized/solady:v0.1.22"
-  DEFAULT_REPOS: "ithacaxyz/account:v0.3.2,Vectorized/solady:v0.1.22"
+  # Repos to benchmark per step. Each comma-separated entry has the form
+  #   org/repo[:rev][ <extra args>]
+  # where anything after the first whitespace is appended to every benchmark
+  # command for that repo (use this to skip a broken test contract via e.g.
+  # `--nmc BrokenTest`, so a single failing test does not fail the whole CI).
+  TEST_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest|Base58Test',
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
+    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
+
+  ISOLATE_TEST_REPOS: >-
+    ithacaxyz/account:v0.5.7 --nmc SimulateExecuteTest,
+    vectorized/solady:v0.1.26 --nmc 'SafeTransferLibTest|LifebuoyTest|LibBitTest|Base58Test',
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75 --nmc 'TickMathTestTest',
+    sparkdotfi/spark-psm:v1.0.0 --nmc PSMInvariants_TimeBasedRateSetting_WithTransfers_WithPocketSetting
+
+  BUILD_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    vectorized/solady:v0.1.26,
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0
+
+  COVERAGE_REPOS: >-
+    ithacaxyz/account:v0.5.7,
+    aave/aave-v4:v0.5.11,
+    uniswap/v4-core:46c6834698c48bc4a463a86d8420f4eb1d7f3b75,
+    sparkdotfi/spark-psm:v1.0.0
+
   RUSTC_WRAPPER: "sccache"
 
 jobs:
@@ -78,7 +107,7 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
+          REPOS: ${{ github.event.inputs.repos || env.TEST_REPOS }}
         run: |
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
@@ -90,7 +119,7 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.VECTORIZED_SOLADY }}
+          REPOS: ${{ github.event.inputs.repos || env.ISOLATE_TEST_REPOS }}
         run: |
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
@@ -102,7 +131,7 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
-          REPOS: ${{ github.event.inputs.repos || env.DEFAULT_REPOS }}
+          REPOS: ${{ github.event.inputs.repos || env.BUILD_REPOS }}
         run: |
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
@@ -114,10 +143,11 @@ jobs:
         env:
           FOUNDRY_DIR: ${{ github.workspace }}/.foundry
           VERSIONS: ${{ github.event.inputs.versions || 'stable,nightly' }}
+          REPOS: ${{ github.event.inputs.repos || env.COVERAGE_REPOS }}
         run: |
           ./target/release/foundry-bench --output-dir ./benches --force-install \
             --versions "$VERSIONS" \
-            --repos ${{ env.ITHACAXYZ_ACCOUNT }} \
+            --repos "$REPOS" \
             --benchmarks forge_coverage \
             --output-file forge_coverage_bench.md
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -48,7 +48,7 @@ jobs:
         with:
           toolchain: stable
 
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
 

--- a/.github/workflows/ci-mpp.yml
+++ b/.github/workflows/ci-mpp.yml
@@ -1,0 +1,55 @@
+name: CI MPP
+
+permissions: {}
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTC_WRAPPER: "sccache"
+
+jobs:
+  mpp-check:
+    runs-on: depot-ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    steps:
+      # Checkout the repository
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
+        with:
+          toolchain: stable
+
+      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2
+
+      # Build and install binaries
+      - name: Build and install Foundry binaries
+        run: |
+          cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
+          echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
+
+      - name: Run MPP e2e test
+        env:
+          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
+          MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
+          MPP_DEPOSIT: "1000000"
+        run: |
+          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
+            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
+            exit 0
+          fi
+          mkdir -p ~/.tempo/wallet
+          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
+          ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"

--- a/.github/workflows/ci-tempo.yml
+++ b/.github/workflows/ci-tempo.yml
@@ -36,7 +36,7 @@ env:
   RUSTC_WRAPPER: "sccache"
 
 jobs:
-  sanity-check:
+  tempo-check:
     runs-on: depot-ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -58,21 +58,6 @@ jobs:
         run: |
           cargo build --profile dev --locked -p forge -p cast -p anvil -p chisel
           echo "${{ github.workspace }}/target/debug" >> "$GITHUB_PATH"
-
-      - name: Run MPP e2e test
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
-        env:
-          TEMPO_KEYS_TOML_B64: ${{ secrets.TEMPO_KEYS_TOML_B64 }}
-          MPP_API_KEY: ${{ secrets.MPP_API_KEY }}
-          MPP_DEPOSIT: "1000000"
-        run: |
-          if [ -z "${TEMPO_KEYS_TOML_B64:-}" ]; then
-            echo "::warning::TEMPO_KEYS_TOML_B64 secret not set, skipping MPP e2e"
-            exit 0
-          fi
-          mkdir -p ~/.tempo/wallet
-          echo "$TEMPO_KEYS_TOML_B64" | tr -d '[:space:]' | base64 -d > ~/.tempo/wallet/keys.toml
-          ./.github/scripts/tempo-mpp.sh "$(which cast | xargs dirname)"
 
       # TODO(upstream): re-enable when flaky devnet faucet is fixed
       # - name: Run Tempo check on devnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo test --workspace --doc --locked
@@ -89,7 +89,7 @@ jobs:
         with:
           toolchain: nightly
           components: clippy
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - run: cargo clippy --workspace --all-targets --all-features --locked
@@ -123,7 +123,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: forge fmt

--- a/.github/workflows/crate-checks.yml
+++ b/.github/workflows/crate-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
         with:
           tool: cargo-hack

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -108,3 +108,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64,linux/arm64
           push: true
+          no-cache: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: nightly
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
       - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build documentation

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,7 +15,6 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: full
-  RUSTC_WRAPPER: "sccache"
 
 jobs:
   docs:
@@ -31,8 +30,6 @@ jobs:
         with:
           toolchain: nightly
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
       - name: Build documentation
         run: cargo doc --workspace --all-features --no-deps --document-private-items --locked
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
         with:
           toolchain: stable
           targets: ${{ matrix.target }}
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
       - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
         if: ${{ contains(matrix.runner, 'depot') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -150,11 +150,6 @@ jobs:
           targets: ${{ matrix.target }}
       - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
 
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-        if: ${{ contains(matrix.runner, 'depot') }}
-      - run: printf 'RUSTC_WRAPPER=sccache\n' >> "$GITHUB_ENV"
-        if: ${{ contains(matrix.runner, 'depot') }}
-
       - name: Apple M1 setup
         if: matrix.target == 'aarch64-apple-darwin'
         run: |

--- a/.github/workflows/test-flaky.yml
+++ b/.github/workflows/test-flaky.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
         with:
           tool: nextest

--- a/.github/workflows/test-isolate.yml
+++ b/.github/workflows/test-isolate.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # master
         with:
           toolchain: stable
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
         with:
           tool: nextest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         with:
           toolchain: stable
           target: ${{ matrix.target }}
-      - uses: rui314/setup-mold@725a8794d15fc7563f59595bd9556495c0564878 # v1
+      - uses: rui314/setup-mold@9c9c13bf4c3f1adef0cc596abc155580bcb04444 # v1
       - uses: taiki-e/install-action@58e862542551f667fa44c8a2a4a1d64ad477c96a # v2.75.17
         with:
           tool: nextest

--- a/benches/LATEST.md
+++ b/benches/LATEST.md
@@ -1,6 +1,6 @@
 # Foundry Benchmark Results
 
-**Date**: 2025-10-02 12:14:23
+**Date**: 2026-04-24 23:10:24
 
 ## Repositories Tested
 
@@ -8,66 +8,67 @@
 2. [Vectorized/solady](https://github.com/Vectorized/solady)
 3. [Uniswap/v4-core](https://github.com/Uniswap/v4-core)
 4. [sparkdotfi/spark-psm](https://github.com/sparkdotfi/spark-psm)
+5. [aave/aave-v4](https://github.com/aave/aave-v4)
 
 ## Foundry Versions
 
-- **v1.3.6**: forge Version: 1.3.6-v1.3.6 (d241588 2025-09-16)
-- **v1.4.0-rc1**: forge Version: 1.4.0-v1.4.0-rc1 (bd0e4a7 2025-10-01)
+- **v1.5.1**: forge Version: 1.5.1-v1.5.1 (b0a9dd9 2025-12-19)
+- **nightly**: forge Version: 1.6.0-nightly (a249f5c 2026-04-24)
 
 ## Forge Test
 
-| Repository           | v1.3.6  | v1.4.0-rc1 |
-| -------------------- | ------- | ---------- |
-| ithacaxyz-account    | 3.17 s  | 2.94 s     |
-| solady               | 2.28 s  | 2.10 s     |
-| Uniswap-v4-core      | 7.27 s  | 6.13 s     |
-| sparkdotfi-spark-psm | 43.04 s | 44.08 s    |
+| Repository           | v1.5.1   | nightly  |
+| -------------------- | -------- | -------- |
+| vectorized-solady    | 1.46 s   | 1.38 s   |
+| aave-aave-v4         | 4m 14.2s | 3m 29.1s |
 
 ## Forge Fuzz Test
 
-| Repository           | v1.3.6 | v1.4.0-rc1 |
-| -------------------- | ------ | ---------- |
-| ithacaxyz-account    | 3.18 s | 3.02 s     |
-| solady               | 2.39 s | 2.24 s     |
-| Uniswap-v4-core      | 6.84 s | 6.20 s     |
-| sparkdotfi-spark-psm | 3.07 s | 2.72 s     |
+| Repository           | v1.5.1    | nightly  |
+| -------------------- | --------- | -------- |
+| ithacaxyz-account    | 2.81 s    | 1.59 s   |
+| vectorized-solady    | 1.40 s    | 1.34 s   |
+| Uniswap-v4-core      | 3.01 s    | 2.87 s   |
+| sparkdotfi-spark-psm | 2.04 s    | 1.87 s   |
+| aave-aave-v4         | 3m 46.0s  | 3m 17.3s |
 
 ## Forge Test (Isolated)
 
-| Repository           | v1.3.6  | v1.4.0-rc1 |
-| -------------------- | ------- | ---------- |
-| solady               | 2.26 s  | 2.41 s     |
-| Uniswap-v4-core      | 7.22 s  | 7.71 s     |
-| sparkdotfi-spark-psm | 45.53 s | 50.49 s    |
+| Repository           | v1.5.1   | nightly  |
+| -------------------- | -------- | -------- |
+| Uniswap-v4-core      | 3.50 s   | 3.48 s.  |
+| aave-aave-v4         | 4m 14.0s | 3m 53.4s |
 
 ## Forge Build (No Cache)
 
-| Repository           | v1.3.6  | v1.4.0-rc1 |
-| -------------------- | ------- | ---------- |
-| ithacaxyz-account    | 9.16 s  | 9.08 s     |
-| solady               | 14.62 s | 14.69 s    |
-| Uniswap-v4-core      | 2m 3.8s | 2m 5.3s    |
-| sparkdotfi-spark-psm | 13.17 s | 13.14 s    |
+| Repository           | v1.5.1   | nightly  |
+| -------------------- | -------- | -------- |
+| ithacaxyz-account    | 26.06 s  | 26.61 s  |
+| vectorized-solady    | 14.20 s  | 14.26 s  |
+| Uniswap-v4-core      | 2m 1.3s  | 2m 5.0s  |
+| sparkdotfi-spark-psm | 15.16 s  | 15.30 s  |
+| aave-aave-v4         | 3m 37.0s | 3m 35.1s |
 
 ## Forge Build (With Cache)
 
-| Repository           | v1.3.6  | v1.4.0-rc1 |
-| -------------------- | ------- | ---------- |
-| ithacaxyz-account    | 0.156 s | 0.113 s    |
-| solady               | 0.089 s | 0.094 s    |
-| Uniswap-v4-core      | 0.133 s | 0.127 s    |
-| sparkdotfi-spark-psm | 0.173 s | 0.131 s    |
+| Repository           | v1.5.1  | nightly |
+| -------------------- | ------- | ------- |
+| ithacaxyz-account    | 0.167 s | 0.201 s |
+| vectorized-solady    | 0.099 s | 0.098 s |
+| Uniswap-v4-core      | 0.139 s | 0.140 s |
+| sparkdotfi-spark-psm | 0.168 s | 0.173 s |
+| aave-aave-v4         | 0.370 s | 0.357 s |
 
 ## Forge Coverage
 
-| Repository           | v1.3.6   | v1.4.0-rc1 |
-| -------------------- | -------- | ---------- |
-| ithacaxyz-account    | 14.91 s  | 13.34 s    |
-| Uniswap-v4-core      | 1m 34.8s | 1m 30.3s   |
-| sparkdotfi-spark-psm | 3m 49.3s | 3m 40.2s   |
+| Repository           | v1.5.1    | nightly    |
+| -------------------- | --------- | ---------- |
+| Uniswap-v4-core      | 1m 13.9s  | 1m 10.3s   |
+| sparkdotfi-spark-psm | 2m 54.7s  | 2m 50.0s   |
+| aave-aave-v4         | 11m 20.8s | 10m 58.7s  |
 
 ## System Information
 
 - **OS**: macos
-- **CPU**: 8
-- **Rustc**: rustc 1.90.0-nightly (3014e79f9 2025-07-15)
+- **CPU**: 12
+- **Rustc**: rustc 1.95.0 (59807616e 2026-04-14)

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -24,46 +24,53 @@ pub struct RepoConfig {
     pub org: String,
     pub repo: String,
     pub rev: String,
+    /// Optional extra arguments appended to every benchmark command for this
+    /// repo (e.g. `--nmc BrokenTest` to skip a broken test contract).
+    pub extra_args: Option<String>,
 }
 
 impl FromStr for RepoConfig {
     type Err = eyre::Error;
 
+    /// Parse a repo spec of the form `org/repo[:rev][ <extra args...>]`.
+    ///
+    /// Anything after the first whitespace is treated as extra arguments
+    /// appended to every benchmark command for this repo.
     fn from_str(spec: &str) -> Result<Self> {
-        // Split by ':' first to separate repo path from optional rev
-        let parts: Vec<&str> = spec.splitn(2, ':').collect();
-        let repo_path = parts[0];
-        let custom_rev = parts.get(1).copied();
+        let spec = spec.trim();
+        // Anything after the first whitespace is per-repo extra args.
+        let (head, extra_args) = match spec.split_once(char::is_whitespace) {
+            Some((head, rest)) => (head, Some(rest.trim().to_string())),
+            None => (spec, None),
+        };
 
-        // Now split the repo path by '/'
-        let path_parts: Vec<&str> = repo_path.split('/').collect();
-        if path_parts.len() != 2 {
-            eyre::bail!("Invalid repo format '{}'. Expected 'org/repo' or 'org/repo:rev'", spec);
-        }
+        let (repo_path, custom_rev) = match head.split_once(':') {
+            Some((path, rev)) => (path, Some(rev)),
+            None => (head, None),
+        };
 
-        let org = path_parts[0];
-        let repo = path_parts[1];
+        let (org, repo) = repo_path.split_once('/').ok_or_else(|| {
+            eyre::eyre!("Invalid repo format '{spec}'. Expected 'org/repo' or 'org/repo:rev'")
+        })?;
 
-        // Try to find this repo in BENCHMARK_REPOS to get the full config
-        let existing_config = BENCHMARK_REPOS.iter().find(|r| r.org == org && r.repo == repo);
-
-        let config = if let Some(existing) = existing_config {
-            // Use existing config but allow custom rev to override
-            let mut config = existing.clone();
-            if let Some(rev) = custom_rev {
-                config.rev = rev.to_string();
-            }
-            config
-        } else {
-            // Create new config with custom rev or default
-            // Name should follow the format: org-repo (with hyphen)
-            Self {
+        // Inherit defaults from BENCHMARK_REPOS when available, otherwise build
+        // a fresh config. Custom rev / extra args always override.
+        let mut config = BENCHMARK_REPOS
+            .iter()
+            .find(|r| r.org == org && r.repo == repo)
+            .cloned()
+            .unwrap_or_else(|| Self {
                 name: format!("{org}-{repo}"),
                 org: org.to_string(),
                 repo: repo.to_string(),
-                rev: custom_rev.unwrap_or("main").to_string(),
-            }
-        };
+                rev: "main".to_string(),
+                extra_args: None,
+            });
+
+        if let Some(rev) = custom_rev {
+            config.rev = rev.to_string();
+        }
+        config.extra_args = extra_args;
 
         let _ = sh_println!("Parsed repo spec '{spec}' -> {config:?}");
         Ok(config)
@@ -78,12 +85,14 @@ pub fn default_benchmark_repos() -> Vec<RepoConfig> {
             org: "ithacaxyz".to_string(),
             repo: "account".to_string(),
             rev: "main".to_string(),
+            extra_args: None,
         },
         RepoConfig {
             name: "solady".to_string(),
             org: "Vectorized".to_string(),
             repo: "solady".to_string(),
             rev: "main".to_string(),
+            extra_args: None,
         },
     ]
 }
@@ -113,6 +122,8 @@ pub struct BenchmarkProject {
     pub name: String,
     pub temp_project: TempProject,
     pub root_path: PathBuf,
+    /// Optional extra arguments appended to every benchmark command.
+    pub extra_args: Option<String>,
 }
 
 impl BenchmarkProject {
@@ -159,7 +170,20 @@ impl BenchmarkProject {
         Self::install_npm_dependencies(&root_path)?;
 
         sh_println!("  ✅ Project {} setup complete at {}", config.name, root);
-        Ok(Self { name: config.name.clone(), root_path, temp_project })
+        Ok(Self {
+            name: config.name.clone(),
+            root_path,
+            temp_project,
+            extra_args: config.extra_args.clone(),
+        })
+    }
+
+    /// Append `self.extra_args` to a benchmark shell command, if any.
+    fn cmd(&self, base: &str) -> String {
+        match self.extra_args.as_deref().map(str::trim).filter(|s| !s.is_empty()) {
+            Some(extra) => format!("{base} {extra}"),
+            None => base.to_string(),
+        }
     }
 
     /// Install npm dependencies if package.json exists
@@ -286,7 +310,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_test",
             version,
-            "forge test",
+            &self.cmd("forge test"),
             runs,
             Some("forge build"),
             None,
@@ -305,7 +329,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_with_cache",
             version,
-            "FOUNDRY_LINT_LINT_ON_BUILD=false forge build",
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
             runs,
             None,
             Some("forge build"),
@@ -325,7 +349,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_build_no_cache",
             version,
-            "FOUNDRY_LINT_LINT_ON_BUILD=false forge build",
+            &self.cmd("FOUNDRY_LINT_LINT_ON_BUILD=false forge build"),
             runs,
             Some("forge clean"),
             None,
@@ -345,7 +369,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_fuzz_test",
             version,
-            r#"forge test --match-test "test[^(]*\([^)]+\)""#,
+            &self.cmd(r#"forge test --match-test "test[^(]*\([^)]+\)""#),
             runs,
             Some("forge build"),
             None,
@@ -366,7 +390,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_coverage",
             version,
-            "forge coverage --ir-minimum",
+            &self.cmd("forge coverage --ir-minimum"),
             runs,
             None,
             None,
@@ -386,7 +410,7 @@ impl BenchmarkProject {
         self.hyperfine(
             "forge_isolate_test",
             version,
-            "forge test --isolate",
+            &self.cmd("forge test --isolate"),
             runs,
             Some("forge build"),
             None,

--- a/benches/src/main.rs
+++ b/benches/src/main.rs
@@ -48,8 +48,16 @@ struct Cli {
     #[clap(long, value_delimiter = ',')]
     benchmarks: Option<Vec<String>>,
 
-    /// Run only on specific repositories (comma-separated in org/repo[:rev] format:
-    /// ithacaxyz/account,Vectorized/solady:main,foundry-rs/foundry:v1.0.0)
+    /// Comma-separated list of repositories to benchmark.
+    ///
+    /// Each entry has the form `org/repo[:rev][ <extra args...>]`. Anything
+    /// after the first whitespace is appended to every benchmark command for
+    /// that repo (handy to skip a broken test contract via e.g.
+    /// `--nmc BrokenTest`).
+    ///
+    /// Examples:
+    ///   `ithacaxyz/account:v0.5.7`
+    ///   `vectorized/solady:v0.1.26 --nmc 'LifebuoyTest|LibBitTest'`
     #[clap(long, value_delimiter = ',')]
     repos: Option<Vec<String>>,
 }

--- a/crates/forge/tests/cli/cmd.rs
+++ b/crates/forge/tests/cli/cmd.rs
@@ -3016,7 +3016,7 @@ Ran 1 test suite [ELAPSED]: 1 tests passed, 0 failed, 0 skipped (1 total tests)
   {
     "contract": "test/FallbackWithCalldataTest.sol:CounterWithFallback",
     "deployment": {
-      "gas": 132471,
+      "gas": 132459,
       "size": 396
     },
     "functions": {

--- a/flake.lock
+++ b/flake.lock
@@ -8,11 +8,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1776497206,
-        "narHash": "sha256-Em+RSdFnwyyKPGUBFtQYtVjm+1UvIc9gOR91Y22zlzg=",
+        "lastModified": 1777102577,
+        "narHash": "sha256-ycoy9svZOQgyInu/lwO7IEQtlP5liqYhEcF9m9hPRbM=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "df2295365fb081fe0745449762a771290782c22d",
+        "rev": "f37403486c59376cd285f9685a8ef8ff25c09a3c",
         "type": "github"
       },
       "original": {
@@ -23,11 +23,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776329215,
-        "narHash": "sha256-a8BYi3mzoJ/AcJP8UldOx8emoPRLeWqALZWu4ZvjPXw=",
+        "lastModified": 1776949667,
+        "narHash": "sha256-GMSVw35Q+294GlrTUKlx087E31z7KurReQ1YHSKp5iw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b86751bc4085f48661017fa226dee99fab6c651b",
+        "rev": "01fbdeef22b76df85ea168fbfe1bfd9e63681b30",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1776441750,
-        "narHash": "sha256-1rVfG+mj8R4ze+lSYCa4iAv7FzrB03Cprtxmd1MfZak=",
+        "lastModified": 1776800521,
+        "narHash": "sha256-f8YJfwAOsLFpIoqZuX3yF69UvMLrkx7iVzMH1pJU7cM=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "251df518d73abb5c5d573c4d5d266a3edae9ca5a",
+        "rev": "8954b66d43225e62c92e8bbcc8500191b5cceb1e",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

Add per-repository extra benchmark arguments support, refresh benchmark configuration/results, and adjust CI workflows accordingly.

New Features:
- Allow benchmark repository specs to include optional extra arguments that are appended to all benchmark commands for that repo.

Bug Fixes:
- Adjust the expected gas value for the CounterWithFallback deployment test fixture.

Enhancements:
- Propagate per-repository extra arguments through benchmark projects so all forge benchmark commands can be selectively customized.
- Expand and update the default benchmark repository sets and versions used in automation, including new aave-v4 coverage.
- Improve CLI and workflow documentation for how to specify benchmark repositories and extra arguments.
- Rename the Tempo CI job and split out the MPP e2e test into its own workflow.
- Enable Docker publish workflow builds with cache disabled to ensure fresh images.

CI:
- Update benchmark and core CI workflows to use a newer pinned version of the mold setup action.
- Refine benchmark workflows to use dedicated repo lists per benchmark type and support passing extra per-repo forge arguments.
- Reintroduce the MPP e2e test as a separate CI workflow with proper caching configuration while simplifying the original Tempo workflow.
- Simplify docs and release workflows by removing sccache setup where no longer needed and updating linker setup.