### PR TITLE
Potential fix for code scanning alert no. 226: Artifact poisoning

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -126,6 +126,12 @@ jobs:
           mkdir -p "$ARTIFACT_DIR"
           ls -la "$ARTIFACT_DIR" || true
 
+      - name: Require trusted workflow_run context for artifact consumption
+        if: ${{ github.event_name != 'workflow_run' }}
+        run: |
+          echo "Refusing to consume artifacts outside workflow_run context." >&2
+          exit 1
+
       - name: Download Release Assets
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -135,7 +141,7 @@ jobs:
           # Extract artifacts into an isolated temp directory, not the workspace
           path: ${{ steps.paths.outputs.artifact_dir }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.id || inputs.run_id }}
+          run-id: ${{ github.event.workflow_run.id }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0


### PR DESCRIPTION
Potential fix for [https://github.com/Dargon789/foundry/security/code-scanning/226](https://github.com/Dargon789/foundry/security/code-scanning/226)

The best fix is to remove untrusted artifact source selection from `workflow_dispatch` by refusing manual runs unless they are tied to a trusted `workflow_run` context, or at minimum by not accepting user-supplied `run_id`.  
The least-disruptive, single best change here is:

1. Keep `workflow_dispatch` if needed for operational reasons.
2. Add a guard step before artifact download that fails when the event is `workflow_dispatch`.
3. Make `download-artifact` always use `github.event.workflow_run.id` only.

This preserves existing publish logic for trusted `workflow_run` invocations, avoids changing downstream scripts, and closes both alert variants by eliminating the tainted flow from dispatch input to artifact consumption.

Edits are in `.github/workflows/npm.yml` around:
- before `Download Release Assets` step (new guard step),
- `run-id` in `Download Release Assets` step.

No new imports/dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enforce trusted workflow_run context for consuming release artifacts in the npm GitHub Actions workflow to mitigate artifact poisoning risk.

New Features:
- Add a guard step that fails the npm workflow when artifacts are consumed outside of a workflow_run event context.

Bug Fixes:
- Remove support for user-supplied run_id when downloading artifacts, ensuring artifacts are only fetched from the triggering workflow_run event.