### PR TITLE
chore(ci): increase nightly bench result retention days (#14681)

### DIFF
--- a/.github/workflows/benchmarks-nightly.yml
+++ b/.github/workflows/benchmarks-nightly.yml
@@ -235,7 +235,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bench-results
-          retention-days: 7
+          retention-days: 45
           path: |
             benches/stable-*.json
             benches/nightly-*.json


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

CI:
- Extend nightly benchmark artifact retention from 7 to 45 days in the GitHub Actions workflow.