### PR TITLE
feat: add Amsterdam hardfork mapping and default to Osaka (#14683)

### DIFF
--- a/crates/evm/hardforks/src/lib.rs
+++ b/crates/evm/hardforks/src/lib.rs
@@ -231,6 +231,7 @@ pub fn spec_id_from_ethereum_hardfork(hardfork: EthereumHardfork) -> SpecId {
         EthereumHardfork::Bpo3 | EthereumHardfork::Bpo4 | EthereumHardfork::Bpo5 => {
             unimplemented!()
         }
+        EthereumHardfork::Amsterdam => SpecId::AMSTERDAM,
         f => unreachable!("unimplemented {}", f),
     }
 }
@@ -337,6 +338,7 @@ mod tests {
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Cancun), SpecId::CANCUN);
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Prague), SpecId::PRAGUE);
         assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Osaka), SpecId::OSAKA);
+        assert_eq!(spec_id_from_ethereum_hardfork(EthereumHardfork::Amsterdam), SpecId::AMSTERDAM);
     }
 
     #[test]


### PR DESCRIPTION
feat: add Amsterdam hardfork mapping to SpecId

Add EthereumHardfork::Amsterdam => SpecId::AMSTERDAM mapping in spec_id_from_ethereum_hardfork. Without this, Amsterdam would hit the unreachable!() catch-all arm.

The default evm_version is already set to Osaka.

Amp-Thread-ID: https://ampcode.com/threads/T-019e113f-5bda-711b-8ec5-4841042ba62c

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/foundry-rs/foundry/blob/HEAD/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building the
documentation.
-->

<!-- ** Please select "Allow edits from maintainers" in the PR Options ** -->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Added Documentation
- [ ] Breaking changes

## Summary by Sourcery

Map the Amsterdam Ethereum hardfork to its corresponding SpecId and cover it with tests.

Bug Fixes:
- Prevent Amsterdam hardfork lookups from triggering the unreachable catch-all in spec_id_from_ethereum_hardfork.

Tests:
- Add a unit test asserting that the Amsterdam hardfork resolves to SpecId::AMSTERDAM.